### PR TITLE
Implement a Github release bundle feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Build with Gradle
+        run: ./gradlew -Pversion=${GITHUB_REF##*/v} createReleaseBundle
+
+      - name: create Github Release
+        uses: docker://ghcr.io/anton-yurchenko/git-release:v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRAFT_RELEASE: "false"
+          PRE_RELEASE: "false"
+          CHANGELOG_FILE: "CHANGELOG.md"
+          ALLOW_EMPTY_CHANGELOG: "false"
+          RELEASE_NAME_PREFIX: "Release: "
+        with:
+          args: |
+            ./build/dist/quality-requirements.zip

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 .settings
 .project
 *.DS_Store
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### :rocket: Added
+- [Issue 23](https://github.com/arc42/quality-requirements/issues/23): Create a release bundle with all release assets [@uniqueck](https://github.com/uniqueck)

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,7 @@ plugins {
 apply plugin: 'org.asciidoctor.convert'
 
 
-project.description = "arc42 - Examples for Software Quality Requirements"
-project.version = "0.8.1"
+
 
 ext {
     srcDir  = "$projectDir/src/asciidoc"

--- a/build.gradle
+++ b/build.gradle
@@ -110,5 +110,23 @@ the IntelliJ JetGradle environment.
 
 }
 
+task copyReleaseAssets(dependsOn: 'generateDocx', type: Copy) {
+    from(layout.buildDirectory) {
+        include '**/*.*'
+        exclude 'toArchive'
+    }
+    into layout.buildDirectory.dir("toArchive")
+}
+
+task createReleaseBundle( dependsOn: 'copyReleaseAssets', type: Zip) {
+    description =
+"""
+Create a ZIP file with all release assets.
+"""
+    archiveFileName = "${project.name}.zip"
+    destinationDirectory = layout.buildDirectory.dir('dist')
+    from layout.buildDirectory.dir("toArchive")
+}
+
 
 defaultTasks 'generateDocx'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 project.description = "arc42 - Examples for Software Quality Requirements"
+project.name = "quality-requirements"
 project.version = "0.8.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+project.description = "arc42 - Examples for Software Quality Requirements"
+project.version = "0.8.1"


### PR DESCRIPTION
The goal was to create a release bundle with all necessary release assets, this is done via build.gradle and gradle.properties. I moved the version from build.gradle to gradle.properties, so we can use the tag as version for the release. This is done via `gradle Pversion=${GITHUB_REF##*/v}`.
I introduce a CHANGELOG.md file based on https://keepachangelog.com to add change log entries for the github release page. If you would like to create a new release you have to move the unreleased stuff from CHANGELOG.md to a new section with the matching release version. Tag v0.0.1 means section [0.0.1] - date of release in format year-month-day. After that you have to push the tag to github and thats it.

Fixed #23 